### PR TITLE
Force utf8 external format

### DIFF
--- a/languages.lisp
+++ b/languages.lisp
@@ -42,7 +42,7 @@
   (gethash language *language-name-map*))
 
 (defun load-code-map (file)
-  (with-open-file (stream file)
+  (with-open-file (stream file :external-format :utf8)
     (loop for line = (read stream NIL :eof)
           until (eql line :eof)
           do (destructuring-bind (code &rest names) line


### PR DESCRIPTION
Seems like if Windows doesn't have the default code page set to utf8 there are [problems](https://github.com/yitzchak/common-lisp-jupyter/issues/65#issuecomment-784506300). 

