### PR TITLE
Use :utf-8 instead of :utf8

### DIFF
--- a/languages.lisp
+++ b/languages.lisp
@@ -42,7 +42,7 @@
   (gethash language *language-name-map*))
 
 (defun load-code-map (file)
-  (with-open-file (stream file :external-format :utf8)
+  (with-open-file (stream file :external-format :utf-8)
     (loop for line = (read stream NIL :eof)
           until (eql line :eof)
           do (destructuring-bind (code &rest names) line


### PR DESCRIPTION
Apparently SBCL (at least on Windows) accepts both `:utf8` or `:utf-8` but ccl on Mac only takes `:utf-8`.  Tested on SBCL, CCL, ECL and CLASP.